### PR TITLE
Support for binary deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: node_js
 
 node_js:
  - "0.10"
- - "0.8"
 
 before_install:
+ # first test install of binary
+ - npm install --verbose
+ - make test
+
+install:
+ # next test source compile, so get dependencies
  - sudo apt-add-repository --yes ppa:mapnik/boost
  - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test
  - sudo apt-get -y update -qq
@@ -14,12 +19,9 @@ before_install:
  - make && sudo make install
  - cd ../../
 
-install:
- - npm install mocha
-
 before_script:
  - git clone https://github.com/osmcode/libosmium.git ../libosmium
- - CXX=g++-4.7 npm install --verbose
+ - CXX=g++-4.7 npm install
 
 script:
  - make test

--- a/README.md
+++ b/README.md
@@ -1,13 +1,67 @@
 # node-osmium
 
-Node.js bindings to [libosmium](https://github.com/osmcode/libosmium).
+Fast and flexible Javascript library for working with OpenStreetMap data.
+
+Provides a bindings to the [libosmium](https://github.com/osmcode/libosmium) C++ library.
 
 [![Build Status](https://secure.travis-ci.org/osmcode/node-osmium.png)](http://travis-ci.org/osmcode/node-osmium)
 
 # Depends
 
- - Compiler that supports `-std=c++11` (>= clang++ 3.2 || >= g++ 4.8)
  - Node.js v0.10.x
+
+# Installing
+
+By default, binaries are provided and no external depedencies and no compile is needed.
+
+Just do:
+
+    npm install osmium
+
+We currently provide binaries for 64 bit OS X and 64 bit Linux. Running `npm install` on other
+platforms will fall back to a source compile (see `Developing` below for build details).
+
+# Usage
+
+## Get the bounds of an `.osm` file
+
+```js
+var osmium = require('osmium');
+var file = new osmium.File("test/data/winthrop.osm");
+var reader = new osmium.Reader(file);
+console.log(reader.header())
+{ generator: 'CGImap 0.2.0',
+  bounds: [ -120.2024, 48.4636, -120.1569, 48.4869 ] }
+```
+
+## Parse a `.pbf` file and create a node handler callback to count total nodes
+
+```js
+var osmium = require('osmium');
+var file = new osmium.File("test/data/winthrop.osm");
+var reader = new osmium.Reader(file);
+var handler = new osmium.Handler();
+var nodes = 0;
+handler.on('node',function(node) {
+    ++nodes;
+});
+reader.apply(handler);
+console.log(nodes);
+1525
+```
+
+# Developing
+
+If you wish to develop on `node-osmium` you can check out the code and then build like:
+
+    git clone https://github.com/osmcode/node-osmium.git
+    cd node-osmium
+    make
+    make test
+
+## Source build dependencies
+
+ - Compiler that supports `-std=c++11` (>= clang++ 3.2 || >= g++ 4.8)
  - Boost >= 1.49 with development headers
  - OSM-Binary
  - Protocol buffers
@@ -42,43 +96,3 @@ Set depedencies up on OS X like:
     ./scripts/build_osm-pbf.sh
     # NOTE: in the same terminal then run the build commands
     # Or from a different terminal re-run `source MacOSX.sh`
-
-# Building
-
-To build the bindings:
-
-    git clone https://github.com/osmcode/libosmium.git
-    git clone https://github.com/osmcode/node-osmium.git
-    cd node-osmium
-    npm install
-
-# Testing
-
-Run the tests like:
-
-    npm install mocha
-    make test
-
-# Troubleshooting
-
-If you hit a test error like the below it means you need to run `make test` instead of just `npm test` so that the test data is downloaded:
-
-    1) osmium should be able to create an osmium.Reader:
-         TypeError: Open failed
-
-If you hit an error like the below it means you need a more recent compiler that implements the C++11 language standard
-
-    cc1plus: error: unrecognized command line option ‘-std=c++11’
-
-This error indicates you need the boost development headers installed:
-
-    ../../include/osmium/osm/location.hpp:40:31: fatal error: boost/operators.hpp: No such file or directory
-
-An error like this indicates that your compiler is too old and does not support all needed c++11 features
-
-    ../../include/osmium/io/header.hpp:55:51: sorry, unimplemented: non-static data member initializers
-    ../../include/osmium/io/header.hpp:55:51: error: ISO C++ forbids in-class initialization of non-const static member ‘m_has_multiple_object_versions’
-
-And error like this indicates that you need to do `export CXXFLAGS=-fPIC` and then recompile `libosmpbf`:
-
-    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/4.7/../../../../lib/libosmpbf.a(fileformat.pb.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC

--- a/package.json
+++ b/package.json
@@ -23,14 +23,25 @@
         "type": "git",
         "url": "git://github.com/osmcode/node-osmium.git"
     },
-    "licenses": [ { "type": "Boost" } ],
+    "binary": {
+        "module_name": "osmium",
+        "module_path": "./lib",
+        "remote_uri": "http://node-osmium.s3.amazonaws.com",
+        "template": "{module_name}-v{major}.{minor}.{patch}-{node_abi}-{platform}-{arch}.tar.gz"
+    },
+    "dependencies": {
+        "node-pre-gyp": "~0.1.4"
+    },
+    "bundledDependencies":["node-pre-gyp"],
     "devDependencies": {
         "mocha": "*"
     },
+    "licenses": [ { "type": "Boost" } ],
     "engines": {
         "node": ">= 0.6.13 < 0.11.0"
     },
     "scripts": {
+        "install": "node-pre-gyp rebuild",
         "test": "mocha -R spec"
     }
 }


### PR DESCRIPTION
This updates the documentation and the install process so that `npm install` tries to use a binary instead of a source compile, when possible. Binaries are currently available for 64 bit OS X and Linux and I'll plan to get them continuously building.
