### PR TITLE
Keep back compatibility of Reader with BasicReader

### DIFF
--- a/lib/osmium.js
+++ b/lib/osmium.js
@@ -66,33 +66,19 @@ exports.Reader = function(file) {
     if (typeof(file) == 'string') {
         file = new osmium.File(file);
     }
-    this._file = file;
-
     if (arguments.length == 2) {
         if (typeof(arguments[1]) == 'string' || arguments[1] instanceof osmium.LocationHandler) {
-            var location_handler = arguments[1];
-            this._location_handler = location_handler;
-            this._reader = new osmium.FlexReader(file, location_handler);
+            return new osmium.FlexReader(file, arguments[1]);
         } else {
-            var options = arguments[1];
-            this._reader = new osmium.BasicReader(file, options);
+            return new osmium.BasicReader(file, arguments[1]);
         }
     } else if (arguments.length == 3) {
         var location_handler = arguments[1];
         var options = arguments[2];
-        this._location_handler = location_handler;
-        this._reader = new osmium.FlexReader(file, location_handler, options);
+        return new osmium.FlexReader(file, location_handler, options);
     } else {
         throw new Error('Wrong number of arguments for Reader');
     }
-}
-
-exports.Reader.prototype.read = function() {
-    return this._reader.read();
-}
-
-exports.Reader.prototype.close = function() {
-    return this._reader.close();
 }
 
 // =================================================================


### PR DESCRIPTION
This is an attempt to keep scripts working across 0.3.0 -> 0.4.0 that used `osmium.Reader` like https://github.com/osmlab/mapbox-studio-humanitarian-print.tm2/blob/master/data/index.js

Running that script currently against the 0.4.0 binaries gives:

```
~/projects/mapbox-studio-humanitarian-print.tm2/data[master]$ node index.js berlin-latest.osm.pbf 

/Users/dane/projects/mapbox-studio-humanitarian-print.tm2/data/index.js:44
osmium.apply(reader, location_handler, handler);
       ^
TypeError: please provide a BasicReader, FlexReader or Buffer object as first parameter
    at Object.<anonymous> (/Users/dane/projects/mapbox-studio-humanitarian-print.tm2/data/index.js:44:8)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
```

@joto can you advise on whether this works? Do we need to store references to the arguments passed in to keep them in scope? /cc @aaronlidman @amyleew