### PR TITLE
Support requesting object type "area" (for FlexReader)

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -49,6 +49,11 @@ namespace node_osmium {
             entities |= osmium::osm_entity_bits::relation;
         }
 
+        v8::Local<v8::Value> want_areas = options->Get(symbol_area);
+        if (want_areas->IsBoolean() && want_areas->BooleanValue()) {
+            entities |= osmium::osm_entity_bits::area;
+        }
+
         v8::Local<v8::Value> want_changesets = options->Get(symbol_changeset);
         if (want_changesets->IsBoolean() && want_changesets->BooleanValue()) {
             entities |= osmium::osm_entity_bits::changeset;


### PR DESCRIPTION
demo/multipolygon/index.js doesn't work yet though: Either it needs to explicitly ask for area objects when creating the FlexReader, or FlexReader should default to osmium::osm_entity_bits::nwra instead of osmium::osm_entity_bits::nwr.

Defaulting to osmium::osm_entity_bits::nwra seems less surprising and more reasonable to me, because (at least for me) getting areas is the main reason for choosing FlexReader over BasicReader.