### PR TITLE
Add GeoJSON serialization to Area object

### DIFF
--- a/src/node_osmium.cpp
+++ b/src/node_osmium.cpp
@@ -5,6 +5,7 @@
 // osmium
 #include <osmium/geom/wkb.hpp>
 #include <osmium/geom/wkt.hpp>
+#include <osmium/geom/geojson.hpp>
 #include <osmium/io/input_iterator.hpp>
 #include <osmium/memory/buffer.hpp>
 #include <osmium/visitor.hpp>
@@ -31,6 +32,7 @@ namespace node_osmium {
     v8::Persistent<v8::Object> module;
     osmium::geom::WKBFactory<> wkb_factory;
     osmium::geom::WKTFactory<> wkt_factory;
+    osmium::geom::GeoJSONFactory<> geojson_factory;
 
     v8::Persistent<v8::String> symbol_OSMEntity;
     v8::Persistent<v8::String> symbol_OSMObject;

--- a/src/osm_area_wrap.hpp
+++ b/src/osm_area_wrap.hpp
@@ -26,6 +26,7 @@ namespace node_osmium {
 
         static v8::Handle<v8::Value> wkb(const v8::Arguments& args);
         static v8::Handle<v8::Value> wkt(const v8::Arguments& args);
+        static v8::Handle<v8::Value> geojson(const v8::Arguments& args);
 
     public:
 


### PR DESCRIPTION
I noticed the `Area` object has `wkb` and `wkt` methods, but lacks the `geojson` method.

I guess this is because the `geojson` methods in `Node` and `Way` are implemented [on the node-osmium side](https://github.com/osmcode/node-osmium/blob/master/lib/osmium.js#L47) rather than relying on libosmium's GeoJSON serialization; with the current API, the same thing is not possible to do for areas.

I've hacked up a fix that uses libosmium's `GeoJSONFactory` to serialize an `Area`, and then parses the resulting string using `JSON.parse`. It feels a bit iffy, but seems to do the job.

Since this is my first dive into node-osmium/libosmium, I totally expect there to be better ways to do this. Any pointers on alternatives or improvements would be great!