### PR TITLE
Test script to run geometry tests against osm-testdata fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,12 @@
     },
     "bundledDependencies":["node-pre-gyp"],
     "devDependencies": {
+        "aws-sdk": "~2.1.26",
+        "geojson-coords": "0.0.0",
         "mocha": "1.x",
-        "aws-sdk": "~2.1.26"
+        "osm-testdata": "1.0.0",
+        "turf-difference": "^2.0.0",
+        "wellknown": "^0.4.0"
     },
     "licenses": [ { "type": "Boost" } ],
     "engines": {

--- a/src/osm_way_wrap.cpp
+++ b/src/osm_way_wrap.cpp
@@ -114,6 +114,10 @@ namespace node_osmium {
 
         const osmium::Way& way = wrapped(args.This());
 
+        if (way.nodes().size() < 2) {
+            return ThrowException(v8::Exception::Error(v8::String::New("Way has no geometry")));
+        }
+
         switch (args.Length()) {
             case 0: {
                 try {
@@ -153,4 +157,3 @@ namespace node_osmium {
     }
 
 } // namespace node_osmium
-

--- a/test/osm-testdata.test.js
+++ b/test/osm-testdata.test.js
@@ -1,0 +1,189 @@
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+
+var testData = require('osm-testdata');
+var wellknown = require('wellknown');
+var flat = require('geojson-coords');
+var difference = require('turf-difference');
+
+var osmium = require('..');
+
+// Check two areas (as geojson geometries) for equality:
+// - they must have the same total number of coordinates
+// - a spatial difference operation should leave no remainder
+function areasEqual(geom1, geom2) {
+    // if (flat(geom1).length !== flat(geom2).length) return false;
+    var diff = difference(geom1, geom2);
+    return !diff;
+}
+
+
+// Parse files from osm-testdata repository
+var tests = ['1', '3', '7', '9'].reduce(function(tests, num) {
+    fs.readdirSync(path.join(testData, num)).forEach(function(testId) {
+        var folder = path.join(testData, num, testId);
+
+        if (fs.statSync(folder).isDirectory()) {
+            var test = {
+                data: path.join(folder, 'data.osm'),
+                valid: fs.readFileSync(path.join(folder, 'result'), 'utf8').trim() === 'valid',
+                info: require(path.join(folder, 'test.json')),
+                wkt: {},
+                geojson: {}
+            };
+
+            var re = /(\d+) (\w+\(.+\))/;
+            ['nodes.wkt', 'ways.wkt'].forEach(function(filename) {
+                var file = path.join(folder, filename);
+                if (!fs.existsSync(file)) return;
+
+                var data = fs.readFileSync(file, 'utf8').trim().split('\n').forEach(function(line) {
+                    var m = line.match(re);
+                    test.wkt[m[1]] = m[2];
+                    test.geojson[m[1]] = wellknown(m[2]);
+                });
+            });
+
+            tests.push(test);
+        }
+    });
+
+    return tests;
+}, []);
+
+
+tests.forEach(function(test) {
+    // use node-osmium to parse the data, create wkt and geojson
+    var file = new osmium.File(test.data, 'osm');
+    var handler = new osmium.Handler();
+    var locator = new osmium.LocationHandler();
+    var reader = new osmium.FlexReader(file, locator);
+    var features = { wkt: {}, geojson: {} };
+    var areas = { wkt: {}, geojson: {} };
+
+    function getGeometry(osm) {
+        var stash = osm.type === 'area' ? areas : features;
+        try { stash.geojson[osm.id] = osm.geojson(); }
+        catch (err) { stash.geojson[osm.id] = err; }
+        try { stash.wkt[osm.id] = osm.wkt(); }
+        catch (err) { stash.wkt[osm.id] = err; }
+    }
+
+    handler.on('node', getGeometry);
+    handler.on('way', getGeometry);
+    handler.on('area', getGeometry);
+    osmium.apply(reader, handler);
+
+    handler.end();
+    reader.close();
+
+    describe(test.info.test_id + ': ' + test.info.description, function() {
+        // test basic feature wkt generation
+        Object.keys(features.wkt).forEach(function(id) {
+            var expected = test.wkt[id];
+            var found = features.wkt[id];
+
+            var matches = found === expected;
+            var errored = found instanceof Error;
+
+            if (test.valid) {
+                it('expected wkt for feature ' + id, function() {
+                    assert.ok(matches);
+                });
+            } else {
+                it('threw error or generated fixed wkt for invalid feature ' + id, function() {
+                    assert.ok(matches || errored);
+                });
+            }
+
+            delete test.wkt[id];
+        });
+
+        it('all expected wkt for test', function() {
+            assert.equal(Object.keys(test.wkt).length, 0);
+        });
+
+        // test basic feature geojson generation
+        Object.keys(features.geojson).forEach(function(id) {
+            var expected = test.geojson[id];
+            var found = features.geojson[id];
+
+            var matches = JSON.stringify(found) === JSON.stringify(expected);
+            var errored = found instanceof Error;
+
+            if (test.valid) {
+                it('expected geojson for feature ' + id, function() {
+                    assert.ok(matches);
+                });
+            } else {
+                it('threw error or generated fixed geojson for invalid feature ' + id, function() {
+                    assert.ok(matches || errored);
+                });
+            }
+
+            delete test.geojson[id];
+        });
+
+        it('all expected geojson', function() {
+            assert.equal(Object.keys(test.geojson).length, 0);
+        });
+
+        if (!test.info.areas) return;
+
+        // test area generation
+        if (test.valid) {
+            test.info.areas.default.forEach(function(expectedArea) {
+                // osmium doubles id values when creating an area from a way and
+                // doubles + 1 when creating an area from a relation
+                var foundWkt = areas.wkt[2 * expectedArea.from_id] || areas.wkt[(2 * expectedArea.from_id) + 1];
+                var foundGeojson = areas.geojson[2 * expectedArea.from_id] || areas.geojson[(2 * expectedArea.from_id) + 1];
+                var expectedGeojson = wellknown(expectedArea.wkt);
+
+                it('generated wkt area for feature ' + expectedArea.from_id, function() {
+                    assert.ok(areasEqual(wellknown(foundWkt), expectedGeojson));
+                });
+                it('generated geojson area for feature ' + expectedArea.from_id, function() {
+                    assert.ok(areasEqual(foundGeojson, expectedGeojson));
+                });
+            });
+        } else {
+            (test.info.areas.fix || test.info.areas.location || test.info.areas.default || []).forEach(function(fixedArea) {
+                var expected = fixedArea.wkt;
+                var foundWkt = areas.wkt[2 * fixedArea.from_id] || areas.wkt[(2 * fixedArea.from_id) + 1];
+                var foundGeojson = areas.geojson[2 * fixedArea.from_id] || areas.geojson[(2 * fixedArea.from_id) + 1];
+                var erroredWkt = foundWkt instanceof Error;
+                var erroredGeojson = foundGeojson instanceof Error;
+                var matchesWkt = erroredWkt ? 'false' : areasEqual(wellknown(foundWkt), wellknown(expected));
+                var matchesGeojson = erroredGeojson ? 'false' : areasEqual(foundGeojson, wellknown(expected));
+
+                it('threw error or generated fixed wkt for invalid area ' + fixedArea.from_id, function() {
+                    assert.ok(matchesWkt || erroredWkt);
+                });
+
+                it('threw error or generated fixed geojson for invalid area ' + fixedArea.from_id, function() {
+                    assert.ok(matchesGeojson || erroredGeojson);
+                });
+
+                delete areas.wkt[2 * fixedArea.from_id];
+                delete areas.wkt[2 * fixedArea.from_id + 1];
+                delete areas.geojson[2 * fixedArea.from_id];
+                delete areas.geojson[2 * fixedArea.from_id + 1];
+            });
+
+            Object.keys(areas.wkt).forEach(function(id) {
+                var leftoverArea = areas.wkt[id];
+                it('wkt threw error for invalid area ' + id, function() {
+                    assert.ok(leftoverArea instanceof Error);
+                });
+            });
+
+            Object.keys(areas.geojson).forEach(function(id) {
+                var leftoverArea = areas.geojson[id];
+                it('geojson threw error for invalid area ' + id, function() {
+                    assert.ok(leftoverArea instanceof Error);
+                });
+            });
+        }
+    });
+});


### PR DESCRIPTION
This PR attempts to compare node-osmium `.wkt()` and `.geojson()` outputs to fixtures in https://github.com/osmcode/osm-testdata. There are some caveats:

This depends on osm-testdata being npm install-able: https://github.com/osmcode/osm-testdata/pull/8. In the meantime, you can pull that branch of osm-testdata and `npm link` it.

I threw an exception when a way has less than two nodes. This cleared up a lot of test failure in the `1` and `7` sets but isn't really related to this PR and I can remove if needed.

A few tests do not pass. Here's my assessment of why:

### Mishandled identical nodes

* 122: way.geojson() should throw error when way has two identical node
* 123: way.geojson() should throw error when way has two nodes with identical locations
* 124: way.geojson() should remove duplicate coordinates and create a two-point linestring
* 732: way.geojson() must remove duplicate coordinates to match fixture
* 747: way.geojson() must remove duplicate coordinates to match fixture
* 748: way.geojson() must remove duplicate coordinates to match fixture

### Extraneous coordinates

These are not strictly errors: the areas are the same but they contain extraneous coordinates. In fact the whole process of checking for equality in areas is tricky. I used https://github.com/turfjs/turf-difference (relies on JSTS) to assert that the areas are equal, but at first I also asserted that the expected and generated geometries had the same number of coordinates. With that later check, the following tests fail.

* 760: area.wkt() and area.geojson() outputs contain an extraneous coordinate
* 761: area.wkt() and area.geojson() outputs contain an extraneous coordinate
* 762: area.wkt() and area.geojson() outputs contain an extraneous coordinate
