### PR TITLE
npmignore lib/binding

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ mason_packages
 appveyor.yml
 build-local-test.bat
 bootstrap.sh
+lib/binding


### PR DESCRIPTION
Keeps the binaries out of the npm bundles.