### PR TITLE
add protozero dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you want top performance use libosmium directly in C++. These node-osmium bin
 
  - Node.js v0.10.x, v4.x, or v5.x (v5 and v5 supported only with node-osmium >= 0.5.x)
  - libosmium (https://github.com/osmcode/libosmium)
+ - protozero (https://github.com/mapbox/protozero)
  - Mocha (http://visionmedia.github.io/mocha/, for tests)
 
 ## Installing


### PR DESCRIPTION
I found that protozero is necessary to successfully build node-osmium.