### PR TITLE
[WIP] build binaries against lamda compatible libstdc++-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
     packages:
      - pkg-config
      - make
-     - libstdc++-5-dev
+     - libstdc++-4.8-dev
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmium",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "libosmium_version": "v2.10.3",
   "description": "Node.js bindings to Osmium",
   "url": "https://github.com/osmcode/node-osmium",


### PR DESCRIPTION
Downgrading the libstdc++ version to 4.8 to ensure a lower GLIBCXX requirement such that binaries will work out of the box without an upgraded libstdc++ on platforms like amazon linux