### PR TITLE
Upgrade to libosmium 2.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
 env:
   global:
    - JOBS: 8
-   - CLANG_VERSION: "3.8.0"
+   - CLANG_VERSION: "4.0.1"
    - secure: Ac0sNxaMmm/4NLJwjB5W74wNNrXH2cFz4qADJSJwGr+p78NVrp+3B70Nlffg6sf6sq57KeoQi5EbUNSa4fjLS2FqJJDr5U8cOA4nt5tPGm8cucdAyr4VCREEddtV4jfIcNN0/I/DKIK4d744SmpqomVYqTUFOVK8LOT4vAX3tTo=
    - secure: bsD0VyN6F6+ratG/C2AB1GrbmaPGyvaAgjZXd7tsQPYl+TR3BT643T9GikgN5IJdbjVBOJDfSqk76g/UlfLl9bRnoybP8tJsZJhCyMYKyRNGJZBIOyEVe6j5FrcT5ejBO0EIGaw2fXwSkG92pg7CFQOAPkVNgcl/H0XNdMa3Q/8=
 
@@ -89,8 +89,8 @@ before_install:
 install:
 - source ./bootstrap.sh
 - if [[ $(uname -s) == 'Linux' ]]; then
-     ./.mason/mason install clang ${CLANG_VERSION};
-     export PATH=$(./.mason/mason prefix clang ${CLANG_VERSION})/bin:${PATH};
+     ./mason/mason install clang++ ${CLANG_VERSION};
+     export PATH=$(./mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH};
      export CXX="ccache clang++ -Qunused-arguments";
      export CC="ccache clang -Qunused-arguments";
      $CXX --version

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,42 +4,35 @@ set -eu
 set -o pipefail
 
 function dep() {
-    ./.mason/mason install $1 $2
-    ./.mason/mason link $1 $2
+    ./mason/mason install $1 $2
+    ./mason/mason link $1 $2
 }
 
 # default to clang
 CXX=${CXX:-clang++}
 
 function all_deps() {
-    dep boost 1.61.0
-    dep expat 2.1.1
+    dep boost 1.63.0
+    dep expat 2.2.0
     dep bzip2 1.0.6
     dep zlib system
     dep sparsehash 2.0.2
 }
 
-MASON_VERSION="b709931"
+MASON_VERSION="0.14.1"
 
 function setup_mason() {
-    if [[ ! -d ./.mason ]]; then
-        git clone https://github.com/mapbox/mason.git ./.mason
-        (cd ./.mason && git checkout ${MASON_VERSION})
-    else
-        echo "Updating to latest mason"
-        (cd ./.mason && git fetch && git checkout ${MASON_VERSION})
-    fi
+    mkdir -p ./mason
+    curl -sSfL https://github.com/mapbox/mason/archive/v${MASON_VERSION}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
+    export PATH=$(pwd)/mason:$PATH
     export MASON_HOME=$(pwd)/mason_packages/.link
-    export PATH=$(pwd)/.mason:$PATH
     export CXX=${CXX:-clang++}
     export CC=${CC:-clang}
 }
 
 function main() {
     setup_mason
-    if [[ ! -d ${MASON_HOME} ]]; then
-        all_deps
-    fi
+    all_deps
     export C_INCLUDE_PATH="${MASON_HOME}/include"
     export CPLUS_INCLUDE_PATH="${MASON_HOME}/include"
     export CXXFLAGS="-I${MASON_HOME}/include"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "dependencies": {
-    "nan": "~2.4.0",
-    "node-pre-gyp": "~0.6.26"
+    "nan": "~2.6.2",
+    "node-pre-gyp": "~0.6.36"
   },
   "devDependencies": {
     "aws-sdk": "2.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "osmium",
   "version": "0.5.4",
-  "libosmium_version": "v2.10.3",
+  "libosmium_version": "v2.12.2",
   "description": "Node.js bindings to Osmium",
   "url": "https://github.com/osmcode/node-osmium",
   "homepage": "http://osmcode.org/node-osmium",


### PR DESCRIPTION
This upgrades to the latest stable release of libosmium. It also brings in updates of other minor deps while we are at it: nan, node-pre-gyp, boost headers, expat, and mason.

I'm planning to release this as `osmium@0.5.6` and https://github.com/osmcode/node-osmium/pull/90 as `osmium@0.5.5`, first.