### PR TITLE
MultipolygonCollector requires BasicReader

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -462,7 +462,7 @@ handler.on('area', function(area) {
 
 var mp = new osmium.MultipolygonCollector();
 
-var reader = new osmium.Reader(input_filename);
+var reader = new osmium.BasicReader(input_filename);
 mp.read_relations(reader);
 reader.close();
 


### PR DESCRIPTION
Corrected a line in the tutorial that suggests using `Reader` with `MultipolygonCollector`. That trips this assertion, since either `BasicReader` or `Buffer` is required:

https://github.com/osmcode/node-osmium/blob/b74f9d304de1228b90db1ef7d74d0c613d4aefe4/src/multipolygon_collector_wrap.cpp#L66