### PR TITLE
Remove encrypted keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,6 @@ env:
   global:
    - JOBS: 8
    - CLANG_VERSION: "4.0.1"
-   - secure: Ac0sNxaMmm/4NLJwjB5W74wNNrXH2cFz4qADJSJwGr+p78NVrp+3B70Nlffg6sf6sq57KeoQi5EbUNSa4fjLS2FqJJDr5U8cOA4nt5tPGm8cucdAyr4VCREEddtV4jfIcNN0/I/DKIK4d744SmpqomVYqTUFOVK8LOT4vAX3tTo=
-   - secure: bsD0VyN6F6+ratG/C2AB1GrbmaPGyvaAgjZXd7tsQPYl+TR3BT643T9GikgN5IJdbjVBOJDfSqk76g/UlfLl9bRnoybP8tJsZJhCyMYKyRNGJZBIOyEVe6j5FrcT5ejBO0EIGaw2fXwSkG92pg7CFQOAPkVNgcl/H0XNdMa3Q/8=
 
 before_install:
  # workaround travis rvm bug

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmium",
-  "version": "0.5.6",
+  "version": "0.5.6-testpublish1",
   "libosmium_version": "v2.12.2",
   "protozero_version": "v1.6.1",
   "description": "Node.js bindings to Osmium",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmium",
-  "version": "0.5.6-testpublish1",
+  "version": "0.5.6",
   "libosmium_version": "v2.12.2",
   "protozero_version": "v1.6.1",
   "description": "Node.js bindings to Osmium",


### PR DESCRIPTION
Remove encrypted keys from travis since they are now stored in the settings page of travis-ci.org. Tested a dev publish successfully:

![screen shot 2018-05-30 at 12 02 42 pm](https://user-images.githubusercontent.com/1943001/40741907-9c4d61d8-6401-11e8-9ef2-a9e8e921fa84.png)

cc @joto @springmeyer feel free to merge whenever you need to publish a new version!